### PR TITLE
feat: add github action to run hardhat test on main

### DIFF
--- a/.github/workflows/hardhat-main-ci.yml
+++ b/.github/workflows/hardhat-main-ci.yml
@@ -1,0 +1,30 @@
+name: Hardhat CI on main branch
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - run: yarn install
+      - run: npx --version
+
+      - run: npx hardhat typechain
+      - run: echo "🎉 Hardhat Typechain passed."
+
+      - run: npx hardhat test
+      - run: echo "🎉 Hardhat Test passed."


### PR DESCRIPTION
This PR adds a Github Action that is run every time we merge in main.

The action takes the following  steps:
- yarn install
- checks npx version
- creates types with typechain
- runs the tests using hardhat