### PR TITLE
Bd 353 - Timelock implementation

### DIFF
--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -13,8 +13,14 @@ contract Registry {
 
     mapping(bytes32 => Entry) public modules;
 
-    constructor() {
-        governance = msg.sender;
+    constructor(address _governance) {
+        governance = _governance;
+    }
+
+    ///@notice change the address of the governance
+    ///@param _governance the address of the new governance
+    function changeGovernance(address _governance) external onlyGovernance {
+        governance = _governance;
     }
 
     ///@notice Register a module

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -12,12 +12,12 @@ contract Registry {
 
     mapping(address => Entry) public entries;
 
-    constructor() {
-        owner = msg.sender;
+    constructor(address _owner) {
+        owner = _owner;
     }
 
     function addNewContract(address _contractAddr) external onlyOwner {
-        require(!entries[_contractAddr].exists, 'Entry already exists');
+        require(!entries[_contractAddr].exists, 'Registry::addNewContract: Entry already exists.');
         entries[_contractAddr] = Entry({activated: true, exists: true});
     }
 
@@ -26,7 +26,7 @@ contract Registry {
     }
 
     modifier onlyOwner() {
-        require(msg.sender == owner, 'Only owner');
+        require(msg.sender == owner, 'Registry::onlyOwner: Call must come from owner.');
         _;
     }
 }

--- a/contracts/Timelock.sol
+++ b/contracts/Timelock.sol
@@ -42,7 +42,6 @@ contract Timelock {
     address public admin;
     address public pendingAdmin;
     uint256 public delay;
-    bool public admin_initialized;
 
     mapping(bytes32 => bool) public queuedTransactions;
 
@@ -52,7 +51,6 @@ contract Timelock {
 
         admin = _admin;
         delay = _delay;
-        admin_initialized = false;
     }
 
     /// @notice Sets the minimum time delay
@@ -77,9 +75,6 @@ contract Timelock {
     /// @notice Sets a new address as pending admin
     /// @param _pendingAdmin the pending admin
     function setPendingAdmin(address _pendingAdmin) public onlyAdmin {
-        // allows one time setting of admin for deployment purposes
-        require(!admin_initialized, 'Timelock::setPendingAdmin: Admin has already been set.');
-        admin_initialized = true;
         pendingAdmin = _pendingAdmin;
 
         emit NewPendingAdmin(pendingAdmin);

--- a/contracts/Timelock.sol
+++ b/contracts/Timelock.sol
@@ -3,6 +3,7 @@ pragma solidity 0.7.6;
 
 import '@openzeppelin/contracts/math/SafeMath.sol';
 
+/// @title Locks the registry for a minimum period of time
 contract Timelock {
     using SafeMath for uint256;
 
@@ -54,6 +55,8 @@ contract Timelock {
         admin_initialized = false;
     }
 
+    /// @notice Sets the minimum time delay
+    /// @param _delay the new delay
     function setDelay(uint256 _delay) public onlyAdmin {
         require(_delay >= MINIMUM_DELAY, 'Timelock::setDelay: Delay must exceed minimum delay.');
         require(_delay <= MAXIMUM_DELAY, 'Timelock::setDelay: Delay must not exceed maximum delay.');
@@ -62,6 +65,7 @@ contract Timelock {
         emit NewDelay(delay);
     }
 
+    /// @notice Accepts the pending admin as new admin
     function acceptAdmin() public {
         require(msg.sender == pendingAdmin, 'Timelock::acceptAdmin: Call must come from pendingAdmin.');
         admin = msg.sender;
@@ -70,6 +74,8 @@ contract Timelock {
         emit NewAdmin(admin);
     }
 
+    /// @notice Sets a new address as pending admin
+    /// @param _newPendingAdmin the pending admin
     function setPendingAdmin(address _pendingAdmin) public onlyAdmin {
         // allows one time setting of admin for deployment purposes
         require(!admin_initialized, 'Timelock::setPendingAdmin: Admin has already been set.');
@@ -79,6 +85,13 @@ contract Timelock {
         emit NewPendingAdmin(pendingAdmin);
     }
 
+    /// @notice queues a transaction to be executed after the delay passed
+    /// @param target the target contract address
+    /// @param value the value to be sent
+    /// @param signature the signature of the transaction to be enqueued
+    /// @param data the data of the transaction to be enqueued
+    /// @param eta the minimum timestamp at which the transaction can be executed
+    /// @return the hash of the transaction in bytes
     function queueTransaction(
         address target,
         uint256 value,
@@ -98,6 +111,12 @@ contract Timelock {
         return txHash;
     }
 
+    /// @notice cancels a transaction that has been queued
+    /// @param target the target contract address
+    /// @param value the value to be sent
+    /// @param signature the signature of the transaction to be enqueued
+    /// @param data the data of the transaction to be enqueued
+    /// @param eta the minimum timestamp at which the transaction can be executed
     function cancelTransaction(
         address target,
         uint256 value,
@@ -111,6 +130,13 @@ contract Timelock {
         emit CancelTransaction(txHash, target, value, signature, data, eta);
     }
 
+    /// @notice executes a transaction that has been queued
+    /// @param target the target contract address
+    /// @param value the value to be sent
+    /// @param signature the signature of the transaction to be enqueued
+    /// @param data the data of the transaction to be enqueued
+    /// @param eta the minimum timestamp at which the transaction can be executed
+    /// @return the bytes returned by the call method
     function executeTransaction(
         address target,
         uint256 value,
@@ -141,11 +167,14 @@ contract Timelock {
         return returnData;
     }
 
+    /// @notice gets the current block timestamp
+    /// @return the current block timestamp
     function getBlockTimestamp() internal view returns (uint256) {
         // solium-disable-next-line security/no-block-members
         return block.timestamp;
     }
 
+    /// @notice modifier to check if the sender is the admin
     modifier onlyAdmin() {
         require(msg.sender == admin, 'Timelock::onlyAdmin: Call must come from admin.');
         _;

--- a/contracts/Timelock.sol
+++ b/contracts/Timelock.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.6;
+
+import '@openzeppelin/contracts/math/SafeMath.sol';
+
+contract Timelock {
+    using SafeMath for uint256;
+
+    event NewAdmin(address indexed newAdmin);
+    event NewPendingAdmin(address indexed newPendingAdmin);
+    event NewDelay(uint256 indexed newDelay);
+    event CancelTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint256 value,
+        string signature,
+        bytes data,
+        uint256 eta
+    );
+    event ExecuteTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint256 value,
+        string signature,
+        bytes data,
+        uint256 eta
+    );
+    event QueueTransaction(
+        bytes32 indexed txHash,
+        address indexed target,
+        uint256 value,
+        string signature,
+        bytes data,
+        uint256 eta
+    );
+
+    uint256 public constant GRACE_PERIOD = 14 days;
+    uint256 public constant MINIMUM_DELAY = 6 hours;
+    uint256 public constant MAXIMUM_DELAY = 30 days;
+
+    address public admin;
+    address public pendingAdmin;
+    uint256 public delay;
+    bool public admin_initialized;
+
+    mapping(bytes32 => bool) public queuedTransactions;
+
+    constructor(address _admin, uint256 _delay) public {
+        require(_delay >= MINIMUM_DELAY, 'Timelock::constructor: Delay must exceed minimum delay.');
+        require(_delay <= MAXIMUM_DELAY, 'Timelock::constructor: Delay must not exceed maximum delay.');
+
+        admin = _admin;
+        delay = _delay;
+        admin_initialized = false;
+    }
+
+    receive() external payable {}
+
+    function setDelay(uint256 _delay) public {
+        require(msg.sender == address(this), 'Timelock::setDelay: Call must come from Timelock.');
+        require(_delay >= MINIMUM_DELAY, 'Timelock::setDelay: Delay must exceed minimum delay.');
+        require(_delay <= MAXIMUM_DELAY, 'Timelock::setDelay: Delay must not exceed maximum delay.');
+        delay = _delay;
+
+        emit NewDelay(delay);
+    }
+
+    function acceptAdmin() public {
+        require(msg.sender == pendingAdmin, 'Timelock::acceptAdmin: Call must come from pendingAdmin.');
+        admin = msg.sender;
+        pendingAdmin = address(0);
+
+        emit NewAdmin(admin);
+    }
+
+    function setPendingAdmin(address _pendingAdmin) public {
+        // allows one time setting of admin for deployment purposes
+        if (admin_initialized) {
+            require(msg.sender == address(this), 'Timelock::setPendingAdmin: Call must come from Timelock.');
+        } else {
+            require(msg.sender == admin, 'Timelock::setPendingAdmin: First call must come from admin.');
+            admin_initialized = true;
+        }
+        pendingAdmin = _pendingAdmin;
+
+        emit NewPendingAdmin(pendingAdmin);
+    }
+
+    function queueTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) public returns (bytes32) {
+        require(msg.sender == admin, 'Timelock::queueTransaction: Call must come from admin.');
+        require(
+            eta >= getBlockTimestamp().add(delay),
+            'Timelock::queueTransaction: Estimated execution block must satisfy delay.'
+        );
+
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        queuedTransactions[txHash] = true;
+
+        emit QueueTransaction(txHash, target, value, signature, data, eta);
+        return txHash;
+    }
+
+    function cancelTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) public {
+        require(msg.sender == admin, 'Timelock::cancelTransaction: Call must come from admin.');
+
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        queuedTransactions[txHash] = false;
+
+        emit CancelTransaction(txHash, target, value, signature, data, eta);
+    }
+
+    function executeTransaction(
+        address target,
+        uint256 value,
+        string memory signature,
+        bytes memory data,
+        uint256 eta
+    ) public payable returns (bytes memory) {
+        require(msg.sender == admin, 'Timelock::executeTransaction: Call must come from admin.');
+
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        require(queuedTransactions[txHash], "Timelock::executeTransaction: Transaction hasn't been queued.");
+        require(getBlockTimestamp() >= eta, "Timelock::executeTransaction: Transaction hasn't surpassed time lock.");
+        require(getBlockTimestamp() <= eta.add(GRACE_PERIOD), 'Timelock::executeTransaction: Transaction is stale.');
+
+        queuedTransactions[txHash] = false;
+
+        bytes memory callData;
+
+        if (bytes(signature).length == 0) {
+            callData = data;
+        } else {
+            callData = abi.encodePacked(bytes4(keccak256(bytes(signature))), data);
+        }
+
+        (bool success, bytes memory returnData) = target.call{value: value}(callData);
+        require(success, 'Timelock::executeTransaction: Transaction execution reverted.');
+
+        emit ExecuteTransaction(txHash, target, value, signature, data, eta);
+
+        return returnData;
+    }
+
+    function getBlockTimestamp() internal view returns (uint256) {
+        // solium-disable-next-line security/no-block-members
+        return block.timestamp;
+    }
+}

--- a/contracts/Timelock.sol
+++ b/contracts/Timelock.sol
@@ -75,7 +75,7 @@ contract Timelock {
     }
 
     /// @notice Sets a new address as pending admin
-    /// @param _newPendingAdmin the pending admin
+    /// @param _pendingAdmin the pending admin
     function setPendingAdmin(address _pendingAdmin) public onlyAdmin {
         // allows one time setting of admin for deployment purposes
         require(!admin_initialized, 'Timelock::setPendingAdmin: Admin has already been set.');

--- a/test/Registry.spec.ts
+++ b/test/Registry.spec.ts
@@ -23,7 +23,7 @@ describe('Registry.sol', function () {
     user = signers[1];
 
     //deploy the registry
-    registry = await RegistryFixture().then((registryFix) => registryFix.registryFixture);
+    registry = await RegistryFixture(deployer.address).then((registryFix) => registryFix.registryFixture);
   });
 
   describe('Deployment ', function () {

--- a/test/Registry.spec.ts
+++ b/test/Registry.spec.ts
@@ -58,7 +58,7 @@ describe('Registry.sol', function () {
 
         await Registry.connect(user).addNewContract(fakeId, user.address);
       } catch (err: any) {
-        expect(err.toString()).to.have.string('Only governance function');
+        expect(err.toString()).to.have.string('Registry::onlyGovernance: Call must come from governance.');
       }
     });
   });

--- a/test/Timelock.spec.ts
+++ b/test/Timelock.spec.ts
@@ -3,24 +3,34 @@ const hre = require('hardhat');
 const { getContractAddress } = require('@ethersproject/address');
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
+import { AbiCoder } from 'ethers/lib/utils';
 import { RegistryFixture, TimelockFixture } from './shared/fixtures';
 import { Registry, Timelock } from '../typechain';
 
 describe('Timelock.sol', function () {
   let deployer: any;
+  let deployer2: any;
+  let deployer3: any;
   let user: any;
   let registry: Registry;
   let timelock: Timelock;
+  let abiCoder: AbiCoder;
   const contractAddr1 = '0x00000000219ab540356cBB839Cbe05303d7705Fa';
+  const contractAddr2 = '0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B';
 
   before(async function () {
     await hre.network.provider.send('hardhat_reset');
 
     const signers = await ethers.getSigners();
     deployer = signers[0];
-    user = signers[1];
+    deployer2 = signers[1];
+    deployer3 = signers[2];
+    user = signers[3];
 
-    //deploy the registry
+    //select standard abicoder
+    abiCoder = ethers.utils.defaultAbiCoder;
+
+    //deploy the registry - we need it to test the timelock features
     registry = await RegistryFixture().then((registryFix) => registryFix.registryFixture);
 
     // deploy the timelock
@@ -29,24 +39,69 @@ describe('Timelock.sol', function () {
   });
 
   describe('Deployment ', function () {
-    it('Should assign owner at constructor', async function () {
-      expect(await registry.owner()).to.be.equal(deployer.address);
-    });
-  });
-  describe('Modules update ', function () {
-    it('Should add and activate new contract', async function () {
-      const tx = await registry.connect(deployer).addNewContract(contractAddr1);
-      const entry = await registry.entries(contractAddr1);
-      const activated = entry['activated'];
-      expect(activated).to.be.equal(true);
+    it('Should correctly set timelock admin', async function () {
+      expect(await timelock.admin()).to.equal(deployer.address);
     });
 
-    it('Should fail if it is not called by owner', async function () {
-      try {
-        await registry.connect(user).addNewContract(contractAddr1);
-      } catch (err: any) {
-        expect(err.toString()).to.have.string('Only owner');
-      }
+    it('Should revert if the delay is too small', async function () {
+      const delayTooSmall = 100;
+      const timelockFactory = await ethers.getContractFactory('Timelock');
+      await expect(timelockFactory.deploy(deployer2.address, delayTooSmall)).to.be.revertedWith(
+        'Timelock::constructor: Delay must exceed minimum delay.'
+      );
+    });
+
+    it('Should revert if the delay is too big', async function () {
+      const delayTooSmall = 3e7;
+      const timelockFactory = await ethers.getContractFactory('Timelock');
+      await expect(timelockFactory.deploy(deployer3.address, delayTooSmall)).to.be.revertedWith(
+        'Timelock::constructor: Delay must not exceed maximum delay.'
+      );
+    });
+  });
+
+  //   function setDelay(uint256 _delay) public {
+  //     require(msg.sender == address(this), 'Timelock::setDelay: Call must come from Timelock.');
+  //     require(_delay >= MINIMUM_DELAY, 'Timelock::setDelay: Delay must exceed minimum delay.');
+  //     require(_delay <= MAXIMUM_DELAY, 'Timelock::setDelay: Delay must not exceed maximum delay.');
+  //     delay = _delay;
+
+  //     emit NewDelay(delay);
+  // }
+
+  describe('Admin settings ', function () {
+    it('Should correctly set a new time delay', async function () {
+      const newDelay = 40000;
+      await timelock.connect(deployer).setDelay(newDelay);
+      expect(await timelock.delay()).to.equal(newDelay);
+    });
+  });
+
+  describe('Transaction processing', async function () {
+    it('Should correctly queue a transaction', async function () {
+      const target = registry.address;
+      const value = 0;
+      const signature = 'addNewContract(address)';
+      const data = abiCoder.encode(['address'], [contractAddr2]);
+      const eta = await ethers.provider.getBlock('latest').then((block) => block.timestamp + 51600);
+
+      const txReceipt = await (await timelock.queueTransaction(target, value, signature, data, eta)).wait();
+
+      const events = txReceipt.events!;
+      expect(events[0].event).to.be.equal('QueueTransaction');
+    });
+
+    it('Should correctly cancel a queued transaction', async function () {
+      const target = registry.address;
+      const value = 0;
+      const signature = 'addNewContract(address)';
+      const data = abiCoder.encode(['address'], [contractAddr2]);
+      const eta = (await ethers.provider.getBlock('latest')).timestamp + 51600;
+
+      const txReceipt = await (await timelock.cancelTransaction(target, value, signature, data, eta)).wait();
+
+      const events = txReceipt.events!;
+      expect(events[0].event).to.be.equal('CancelTransaction');
     });
   });
 });

--- a/test/Timelock.spec.ts
+++ b/test/Timelock.spec.ts
@@ -71,12 +71,17 @@ describe('Timelock.sol', function () {
 
     it('Should correctly set a new pending admin', async function () {
       const newPendingAdmin = deployer2.address;
-      await Timelock2.connect(deployer4).setPendingAdmin(newPendingAdmin);
+      await Timelock2.connect(deployer4).setNewPendingAdmin(newPendingAdmin);
       expect(await Timelock2.pendingAdmin()).to.equal(newPendingAdmin);
     });
 
-    it('Should correctly accept a new admin', async function () {
-      await Timelock2.connect(deployer2).acceptAdmin();
+    it('Should correctly accept role of new admin', async function () {
+      await Timelock2.connect(deployer2).acceptAdminRole();
+      expect(await Timelock2.pendingAdminAccepted(deployer2.address)).to.equal(true);
+    });
+
+    it('Should correctly confirm the newly accepted admin', async function () {
+      await Timelock2.connect(deployer4).confirmNewAdmin();
       expect(await Timelock2.admin()).to.equal(deployer2.address);
     });
   });

--- a/test/Timelock.spec.ts
+++ b/test/Timelock.spec.ts
@@ -11,10 +11,10 @@ describe('Timelock.sol', function () {
   let deployer2: any;
   let deployer3: any;
   let deployer4: any;
-  let registry: Registry;
-  let timelock: Timelock;
-  let timelock2: Timelock;
-  let abiCoder: AbiCoder;
+  let Registry: Registry;
+  let Timelock: Timelock;
+  let Timelock2: Timelock;
+  let AbiCoder: AbiCoder;
   const randomContractAddress = '0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B';
 
   before(async function () {
@@ -27,22 +27,22 @@ describe('Timelock.sol', function () {
     deployer4 = signers[3];
 
     //select standard abicoder
-    abiCoder = ethers.utils.defaultAbiCoder;
+    AbiCoder = ethers.utils.defaultAbiCoder;
 
     // deploy the timelock
     const delay = 21600; // 6 hours
-    timelock = (await TimelockFixture(deployer.address, delay)).timelockFixture;
+    Timelock = (await TimelockFixture(deployer.address, delay)).timelockFixture;
 
     // deploy an additional timelock to test admin features
-    timelock2 = (await TimelockFixture(deployer4.address, delay)).timelockFixture;
+    Timelock2 = (await TimelockFixture(deployer4.address, delay)).timelockFixture;
 
     //deploy the registry - we need it to test the timelock features
-    registry = (await RegistryFixture(timelock.address)).registryFixture;
+    Registry = (await RegistryFixture(Timelock.address)).registryFixture;
   });
 
   describe('Deployment ', function () {
     it('Should correctly set timelock admin', async function () {
-      expect(await timelock.admin()).to.equal(deployer.address);
+      expect(await Timelock.admin()).to.equal(deployer.address);
     });
 
     it('Should revert if the delay is too small', async function () {
@@ -65,32 +65,32 @@ describe('Timelock.sol', function () {
   describe('Admin settings ', function () {
     it('Should correctly set a new time delay', async function () {
       const newDelay = 40000;
-      await timelock2.connect(deployer4).setDelay(newDelay);
-      expect(await timelock2.delay()).to.equal(newDelay);
+      await Timelock2.connect(deployer4).setDelay(newDelay);
+      expect(await Timelock2.delay()).to.equal(newDelay);
     });
 
     it('Should correctly set a new pending admin', async function () {
       const newPendingAdmin = deployer2.address;
-      await timelock2.connect(deployer4).setPendingAdmin(newPendingAdmin);
-      expect(await timelock2.pendingAdmin()).to.equal(newPendingAdmin);
+      await Timelock2.connect(deployer4).setPendingAdmin(newPendingAdmin);
+      expect(await Timelock2.pendingAdmin()).to.equal(newPendingAdmin);
     });
 
     it('Should correctly accept a new admin', async function () {
-      await timelock2.connect(deployer2).acceptAdmin();
-      expect(await timelock2.admin()).to.equal(deployer2.address);
+      await Timelock2.connect(deployer2).acceptAdmin();
+      expect(await Timelock2.admin()).to.equal(deployer2.address);
     });
   });
 
   describe('Transaction processing', async function () {
     it('Should correctly queue a transaction', async function () {
-      const target = registry.address;
+      const target = Registry.address;
       const value = 0;
       const signature = 'addNewContract(address)';
-      const data = abiCoder.encode(['address'], [randomContractAddress]);
+      const data = AbiCoder.encode(['address'], [randomContractAddress]);
       const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
       const txReceipt = await (
-        await timelock.connect(deployer).queueTransaction(target, value, signature, data, eta)
+        await Timelock.connect(deployer).queueTransaction(target, value, signature, data, eta)
       ).wait();
 
       const events = txReceipt.events!;
@@ -98,14 +98,14 @@ describe('Timelock.sol', function () {
     });
 
     it('Should correctly cancel a queued transaction', async function () {
-      const target = registry.address;
+      const target = Registry.address;
       const value = 0;
       const signature = 'addNewContract(address)';
-      const data = abiCoder.encode(['address'], [randomContractAddress]);
+      const data = AbiCoder.encode(['address'], [randomContractAddress]);
       const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
       const txReceipt = await (
-        await timelock.connect(deployer).cancelTransaction(target, value, signature, data, eta)
+        await Timelock.connect(deployer).cancelTransaction(target, value, signature, data, eta)
       ).wait();
 
       const events = txReceipt.events!;
@@ -113,14 +113,14 @@ describe('Timelock.sol', function () {
     });
 
     it('Should correctly execute a queued transaction', async function () {
-      const target = registry.address;
+      const target = Registry.address;
       const value = 0;
       const signature = 'addNewContract(address)';
-      const data = abiCoder.encode(['address'], [randomContractAddress]);
+      const data = AbiCoder.encode(['address'], [randomContractAddress]);
       const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
       const queueTxReceipt = await (
-        await timelock.connect(deployer).queueTransaction(target, value, signature, data, eta)
+        await Timelock.connect(deployer).queueTransaction(target, value, signature, data, eta)
       ).wait();
 
       const queueEvents = queueTxReceipt.events!;
@@ -132,7 +132,7 @@ describe('Timelock.sol', function () {
       await ethers.provider.send('evm_increaseTime', [forwardInTime]);
 
       const executeTxReceipt = await (
-        await timelock.connect(deployer).executeTransaction(target, value, signature, data, eta)
+        await Timelock.connect(deployer).executeTransaction(target, value, signature, data, eta)
       ).wait();
 
       const executeEvents = executeTxReceipt.events!;
@@ -140,14 +140,14 @@ describe('Timelock.sol', function () {
     });
 
     it('Should revert if not enough time has passed', async function () {
-      const target = registry.address;
+      const target = Registry.address;
       const value = 0;
       const signature = 'addNewContract(address)';
-      const data = abiCoder.encode(['address'], [randomContractAddress]);
+      const data = AbiCoder.encode(['address'], [randomContractAddress]);
       const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
       const queueTxReceipt = await (
-        await timelock.connect(deployer).queueTransaction(target, value, signature, data, eta)
+        await Timelock.connect(deployer).queueTransaction(target, value, signature, data, eta)
       ).wait();
 
       const queueEvents = queueTxReceipt.events!;
@@ -157,7 +157,7 @@ describe('Timelock.sol', function () {
       const forwardInTime = 1000;
       await ethers.provider.send('evm_increaseTime', [forwardInTime]);
 
-      expect(timelock.connect(deployer).executeTransaction(target, value, signature, data, eta)).to.be.revertedWith(
+      expect(Timelock.connect(deployer).executeTransaction(target, value, signature, data, eta)).to.be.revertedWith(
         "Timelock::executeTransaction: Transaction hasn't surpassed time lock."
       );
     });

--- a/test/Timelock.spec.ts
+++ b/test/Timelock.spec.ts
@@ -11,9 +11,11 @@ describe('Timelock.sol', function () {
   let deployer: any;
   let deployer2: any;
   let deployer3: any;
+  let deployer4: any;
   let user: any;
   let registry: Registry;
   let timelock: Timelock;
+  let timelock2: Timelock;
   let abiCoder: AbiCoder;
   const contractAddr1 = '0x00000000219ab540356cBB839Cbe05303d7705Fa';
   const contractAddr2 = '0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B';
@@ -25,7 +27,8 @@ describe('Timelock.sol', function () {
     deployer = signers[0];
     deployer2 = signers[1];
     deployer3 = signers[2];
-    user = signers[3];
+    deployer4 = signers[3];
+    user = signers[4];
 
     //select standard abicoder
     abiCoder = ethers.utils.defaultAbiCoder;
@@ -34,8 +37,11 @@ describe('Timelock.sol', function () {
     registry = await RegistryFixture().then((registryFix) => registryFix.registryFixture);
 
     // deploy the timelock
-    const delay = 21600;
+    const delay = 21600; // 6 hours
     timelock = (await TimelockFixture(deployer.address, delay)).timelockFixture;
+
+    // deploy an additional timelock to test admin features
+    timelock2 = (await TimelockFixture(deployer4.address, delay)).timelockFixture;
   });
 
   describe('Deployment ', function () {
@@ -60,20 +66,22 @@ describe('Timelock.sol', function () {
     });
   });
 
-  //   function setDelay(uint256 _delay) public {
-  //     require(msg.sender == address(this), 'Timelock::setDelay: Call must come from Timelock.');
-  //     require(_delay >= MINIMUM_DELAY, 'Timelock::setDelay: Delay must exceed minimum delay.');
-  //     require(_delay <= MAXIMUM_DELAY, 'Timelock::setDelay: Delay must not exceed maximum delay.');
-  //     delay = _delay;
-
-  //     emit NewDelay(delay);
-  // }
-
   describe('Admin settings ', function () {
     it('Should correctly set a new time delay', async function () {
       const newDelay = 40000;
-      await timelock.connect(deployer).setDelay(newDelay);
-      expect(await timelock.delay()).to.equal(newDelay);
+      await timelock2.connect(deployer4).setDelay(newDelay);
+      expect(await timelock2.delay()).to.equal(newDelay);
+    });
+
+    it('Should correctly set a new pending admin', async function () {
+      const newPendingAdmin = deployer2.address;
+      await timelock2.connect(deployer4).setPendingAdmin(newPendingAdmin);
+      expect(await timelock2.pendingAdmin()).to.equal(newPendingAdmin);
+    });
+
+    it('Should correctly accept a new admin', async function () {
+      await timelock2.connect(deployer2).acceptAdmin();
+      expect(await timelock2.admin()).to.equal(deployer2.address);
     });
   });
 
@@ -83,9 +91,11 @@ describe('Timelock.sol', function () {
       const value = 0;
       const signature = 'addNewContract(address)';
       const data = abiCoder.encode(['address'], [contractAddr2]);
-      const eta = await ethers.provider.getBlock('latest').then((block) => block.timestamp + 51600);
+      const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
-      const txReceipt = await (await timelock.queueTransaction(target, value, signature, data, eta)).wait();
+      const txReceipt = await (
+        await timelock.connect(deployer).queueTransaction(target, value, signature, data, eta)
+      ).wait();
 
       const events = txReceipt.events!;
       expect(events[0].event).to.be.equal('QueueTransaction');
@@ -96,9 +106,11 @@ describe('Timelock.sol', function () {
       const value = 0;
       const signature = 'addNewContract(address)';
       const data = abiCoder.encode(['address'], [contractAddr2]);
-      const eta = (await ethers.provider.getBlock('latest')).timestamp + 51600;
+      const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
-      const txReceipt = await (await timelock.cancelTransaction(target, value, signature, data, eta)).wait();
+      const txReceipt = await (
+        await timelock.connect(deployer).cancelTransaction(target, value, signature, data, eta)
+      ).wait();
 
       const events = txReceipt.events!;
       expect(events[0].event).to.be.equal('CancelTransaction');

--- a/test/Timelock.spec.ts
+++ b/test/Timelock.spec.ts
@@ -1,6 +1,5 @@
 import '@nomiclabs/hardhat-ethers';
 const hre = require('hardhat');
-const { getContractAddress } = require('@ethersproject/address');
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { AbiCoder } from 'ethers/lib/utils';
@@ -12,13 +11,11 @@ describe('Timelock.sol', function () {
   let deployer2: any;
   let deployer3: any;
   let deployer4: any;
-  let user: any;
   let registry: Registry;
   let timelock: Timelock;
   let timelock2: Timelock;
   let abiCoder: AbiCoder;
-  const contractAddr1 = '0x00000000219ab540356cBB839Cbe05303d7705Fa';
-  const contractAddr2 = '0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B';
+  const randomContractAddress = '0x29D7d1dd5B6f9C864d9db560D72a247c178aE86B';
 
   before(async function () {
     await hre.network.provider.send('hardhat_reset');
@@ -28,7 +25,6 @@ describe('Timelock.sol', function () {
     deployer2 = signers[1];
     deployer3 = signers[2];
     deployer4 = signers[3];
-    user = signers[4];
 
     //select standard abicoder
     abiCoder = ethers.utils.defaultAbiCoder;
@@ -90,7 +86,7 @@ describe('Timelock.sol', function () {
       const target = registry.address;
       const value = 0;
       const signature = 'addNewContract(address)';
-      const data = abiCoder.encode(['address'], [contractAddr2]);
+      const data = abiCoder.encode(['address'], [randomContractAddress]);
       const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
       const txReceipt = await (
@@ -105,7 +101,7 @@ describe('Timelock.sol', function () {
       const target = registry.address;
       const value = 0;
       const signature = 'addNewContract(address)';
-      const data = abiCoder.encode(['address'], [contractAddr2]);
+      const data = abiCoder.encode(['address'], [randomContractAddress]);
       const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
       const txReceipt = await (
@@ -120,7 +116,7 @@ describe('Timelock.sol', function () {
       const target = registry.address;
       const value = 0;
       const signature = 'addNewContract(address)';
-      const data = abiCoder.encode(['address'], [contractAddr2]);
+      const data = abiCoder.encode(['address'], [randomContractAddress]);
       const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
       const queueTxReceipt = await (
@@ -147,7 +143,7 @@ describe('Timelock.sol', function () {
       const target = registry.address;
       const value = 0;
       const signature = 'addNewContract(address)';
-      const data = abiCoder.encode(['address'], [contractAddr2]);
+      const data = abiCoder.encode(['address'], [randomContractAddress]);
       const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
       const queueTxReceipt = await (

--- a/test/Timelock.spec.ts
+++ b/test/Timelock.spec.ts
@@ -1,0 +1,52 @@
+import '@nomiclabs/hardhat-ethers';
+const hre = require('hardhat');
+const { getContractAddress } = require('@ethersproject/address');
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { RegistryFixture, TimelockFixture } from './shared/fixtures';
+import { Registry, Timelock } from '../typechain';
+
+describe('Timelock.sol', function () {
+  let deployer: any;
+  let user: any;
+  let registry: Registry;
+  let timelock: Timelock;
+  const contractAddr1 = '0x00000000219ab540356cBB839Cbe05303d7705Fa';
+
+  before(async function () {
+    await hre.network.provider.send('hardhat_reset');
+
+    const signers = await ethers.getSigners();
+    deployer = signers[0];
+    user = signers[1];
+
+    //deploy the registry
+    registry = await RegistryFixture().then((registryFix) => registryFix.registryFixture);
+
+    // deploy the timelock
+    const delay = 21600;
+    timelock = (await TimelockFixture(deployer.address, delay)).timelockFixture;
+  });
+
+  describe('Deployment ', function () {
+    it('Should assign owner at constructor', async function () {
+      expect(await registry.owner()).to.be.equal(deployer.address);
+    });
+  });
+  describe('Modules update ', function () {
+    it('Should add and activate new contract', async function () {
+      const tx = await registry.connect(deployer).addNewContract(contractAddr1);
+      const entry = await registry.entries(contractAddr1);
+      const activated = entry['activated'];
+      expect(activated).to.be.equal(true);
+    });
+
+    it('Should fail if it is not called by owner', async function () {
+      try {
+        await registry.connect(user).addNewContract(contractAddr1);
+      } catch (err: any) {
+        expect(err.toString()).to.have.string('Only owner');
+      }
+    });
+  });
+});

--- a/test/Timelock.spec.ts
+++ b/test/Timelock.spec.ts
@@ -115,13 +115,12 @@ describe('Timelock.sol', function () {
     it('Should correctly execute a queued transaction', async function () {
       const target = Registry.address;
       const value = 0;
-      const signature = 'addNewContract(address)';
-      const data = AbiCoder.encode(['address'], [randomContractAddress]);
+      const signature = 'addNewContract(bytes32,address)';
+      const fakeId = hre.ethers.utils.keccak256(hre.ethers.utils.toUtf8Bytes('ThisIsATest'));
+      const data = AbiCoder.encode(['bytes32', 'address'], [fakeId, randomContractAddress]);
       const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
-      const queueTxReceipt = await (
-        await Timelock.connect(deployer).queueTransaction(target, value, signature, data, eta)
-      ).wait();
+      const queueTxReceipt = await (await Timelock.queueTransaction(target, value, signature, data, eta)).wait();
 
       const queueEvents = queueTxReceipt.events!;
       expect(queueEvents[0].event).to.be.equal('QueueTransaction');
@@ -142,8 +141,9 @@ describe('Timelock.sol', function () {
     it('Should revert if not enough time has passed', async function () {
       const target = Registry.address;
       const value = 0;
-      const signature = 'addNewContract(address)';
-      const data = AbiCoder.encode(['address'], [randomContractAddress]);
+      const signature = 'addNewContract(bytes32, address)';
+      const fakeId = hre.ethers.utils.keccak256(hre.ethers.utils.toUtf8Bytes('ThisIsATest'));
+      const data = AbiCoder.encode(['bytes32', 'address'], [fakeId, randomContractAddress]);
       const eta = (await ethers.provider.getBlock('latest')).timestamp + 21700;
 
       const queueTxReceipt = await (

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -1,7 +1,7 @@
 import { Contract, ContractReceipt } from 'ethers';
 import { ethers } from 'hardhat';
 import { ContractFactory } from 'ethers';
-import { MockToken, IUniswapV3Pool, TestRouter, Registry } from '../../typechain';
+import { MockToken, IUniswapV3Pool, TestRouter, Registry, Timelock } from '../../typechain';
 const { getContractAddress } = require('@ethersproject/address');
 
 const UniswapV3Pool = require('@uniswap/v3-core/artifacts/contracts/UniswapV3Pool.sol/UniswapV3Pool.json');
@@ -24,6 +24,10 @@ interface RegistryFixture {
   registryFixture: Registry;
 }
 
+interface TimelockFixture {
+  timelockFixture: Timelock;
+}
+
 export async function tokensFixture(name: string, decimal: number): Promise<TokensFixture> {
   const tokenFactory = await ethers.getContractFactory('MockToken');
   const tokenFixture: MockToken = (await tokenFactory.deploy(name, name, decimal)) as MockToken;
@@ -31,17 +35,15 @@ export async function tokensFixture(name: string, decimal: number): Promise<Toke
 }
 
 export async function RegistryFixture(): Promise<RegistryFixture> {
-  const signers = await ethers.getSigners();
-  const deployer = signers[0];
-  const transactionCount = await deployer.getTransactionCount();
-  const futureAddress = getContractAddress({
-    from: deployer.address,
-    nonce: transactionCount,
-  });
-  console.log(futureAddress);
   const registryFactory = await ethers.getContractFactory('Registry');
   const registryFixture: Registry = (await registryFactory.deploy()) as Registry;
   return { registryFixture };
+}
+
+export async function TimelockFixture(deployerAddress: string, delay: number): Promise<TimelockFixture> {
+  const timelockFactory = await ethers.getContractFactory('Timelock');
+  const timelockFixture: Timelock = (await timelockFactory.deploy(deployerAddress, delay)) as Timelock;
+  return { timelockFixture };
 }
 
 export async function poolFixture(

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -34,9 +34,9 @@ export async function tokensFixture(name: string, decimal: number): Promise<Toke
   return { tokenFixture };
 }
 
-export async function RegistryFixture(): Promise<RegistryFixture> {
+export async function RegistryFixture(ownerAddress: string): Promise<RegistryFixture> {
   const registryFactory = await ethers.getContractFactory('Registry');
-  const registryFixture: Registry = (await registryFactory.deploy()) as Registry;
+  const registryFixture: Registry = (await registryFactory.deploy(ownerAddress)) as Registry;
   return { registryFixture };
 }
 

--- a/test/shared/scriptsTest.ts
+++ b/test/shared/scriptsTest.ts
@@ -1,0 +1,5 @@
+import { keeperSetup } from '../../scripts/keeper_setup';
+
+// dev: We want to test that our local deployment scripts run without issues before pushing
+
+keeperSetup();


### PR DESCRIPTION
* Registry will be controlled by the timelock: this is set in the registry constructor (address _owner)
* Timelock is set to 6 hours minimum delay, this can be lowered for the testnet deployment, however in localhost we can speed up the block timestamp with this simple function: `await ethers.provider.send('evm_increaseTime', [timestamp]);`